### PR TITLE
feat: Introduce LoggingMonitor instead of ConsoleMonitor for Logging

### DIFF
--- a/extensions/blockchain/blockchain-catalog-api/src/main/java/berlin/tu/ise/extension/blockchain/catalog/api/BlockchainCatalogApiController.java
+++ b/extensions/blockchain/blockchain-catalog-api/src/main/java/berlin/tu/ise/extension/blockchain/catalog/api/BlockchainCatalogApiController.java
@@ -155,7 +155,7 @@ public class BlockchainCatalogApiController implements BlockchainCatalogApi {
         assert contractDefinitionList != null;
         for (ContractDefinition contract : contractDefinitionList) {
 
-            monitor.info(format("[%s] fetching contract %s", this.getClass().getSimpleName(), contract.getId()));
+            monitor.debug(format("[%s] fetching contract %s", this.getClass().getSimpleName(), contract.getId()));
 
 
             // TODO: Refactor - connect everything together
@@ -246,7 +246,7 @@ public class BlockchainCatalogApiController implements BlockchainCatalogApi {
 
 
         if (contractAsset == null || policyDefinition == null) {
-            monitor.severe(String.format("[%s] Not able to find the Asset with id %s or policy with id %s for the contract %s", this.getClass().getSimpleName(), assetId, policyId, contract.getId()));
+            monitor.debug(String.format("[%s] Not able to find the Asset with id %s or policy with id %s for the contract %s", this.getClass().getSimpleName(), assetId, policyId, contract.getId()));
             return null;
         }
 

--- a/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainAssetCreator.java
+++ b/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainAssetCreator.java
@@ -73,7 +73,6 @@ public class BlockchainAssetCreator implements EventSubscriber {
         // the event only returns the asset id, so we need to get the asset from the index
         AssetCreated assetCreated = (AssetCreated) payload;
         String assetId = assetCreated.getAssetId();
-        monitor.info("Monitor class: " + monitor.getClass().getSimpleName());
         monitor.debug("AssetCreated event triggered for assetId: " + assetId);
         Asset asset = assetIndex.findById(assetId);
         String jsonString = transformToJson(asset);

--- a/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainAssetCreator.java
+++ b/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainAssetCreator.java
@@ -73,6 +73,7 @@ public class BlockchainAssetCreator implements EventSubscriber {
         // the event only returns the asset id, so we need to get the asset from the index
         AssetCreated assetCreated = (AssetCreated) payload;
         String assetId = assetCreated.getAssetId();
+        monitor.info("Monitor class: " + monitor.getClass().getSimpleName());
         monitor.debug("AssetCreated event triggered for assetId: " + assetId);
         Asset asset = assetIndex.findById(assetId);
         String jsonString = transformToJson(asset);

--- a/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainPolicyCreator.java
+++ b/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainPolicyCreator.java
@@ -48,7 +48,7 @@ public class BlockchainPolicyCreator implements EventSubscriber {
         PolicyDefinition policyDefinition = policyDefinitionService.findById(policyId);
 
         String jsonString = transformToJson(policyDefinition);
-        System.out.println(jsonString);
+        monitor.debug(jsonString);
         ReturnObject returnObject = blockchainSmartContractService.sendToPolicySmartContract(jsonString);
         if (returnObject == null) {
             monitor.warning("Something went wrong during the Blockchain Policy creation of the Policy with id " + policyDefinition.getId());

--- a/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainSmartContractService.java
+++ b/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainSmartContractService.java
@@ -358,7 +358,7 @@ public class BlockchainSmartContractService {
                                     continue;
                                 }
                             } else {
-                                monitor.warning("TokenizedPolicyDefinition is null or does not contain @id");
+                                monitor.debug("TokenizedPolicyDefinition is null or does not contain @id");
                             }
 
 
@@ -486,11 +486,11 @@ public class BlockchainSmartContractService {
                             continue;
                         }
                         if (!tokenziedAsset.tokenData.containsKey("@id")) {
-                            monitor.warning("TokenizedAsset does not contain @id");
+                            monitor.debug("TokenizedAsset does not contain @id");
                             continue;
                         }
                         if (!tokenziedAsset.tokenData.containsKey("@context")) {
-                            monitor.warning("TokenziedAsset " + tokenziedAsset.tokenData.getString("@id") + " does not contain @context - Skipping");
+                            monitor.debug("TokenziedAsset " + tokenziedAsset.tokenData.getString("@id") + " does not contain @context - Skipping");
                             continue;
                         }
                         /*
@@ -628,7 +628,7 @@ public class BlockchainSmartContractService {
                                 continue;
                             }
                         } else {
-                            monitor.warning("TokenizedPolicyDefinition is null or does not contain @id");
+                            monitor.debug("TokenizedPolicyDefinition is null or does not contain @id");
                         }
 
                     }

--- a/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainSmartContractService.java
+++ b/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainSmartContractService.java
@@ -97,7 +97,7 @@ public class BlockchainSmartContractService {
             }
 
             while ((returnJson = br.readLine()) != null) {
-                System.out.println(returnJson);
+                monitor.debug(returnJson);
                 ObjectMapper mapper = new ObjectMapper();
                 returnObject = mapper.readValue(returnJson, ReturnObject.class);
             }

--- a/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainSmartContractService.java
+++ b/extensions/blockchain/catalog-listener/src/main/java/berlin/tu/ise/extension/blockchain/catalog/listener/BlockchainSmartContractService.java
@@ -191,7 +191,7 @@ public class BlockchainSmartContractService {
                     }
                     br.close();
 
-                    System.out.println(sb);
+                    monitor.debug(sb.toString());
 
                     tokenziedContractList = mapper.readValue(sb.toString(), new TypeReference<List<TokenizedContract>>() {});
 

--- a/extensions/blockchain/logger/src/main/java/berlin/tu/ise/extension/blockchain/logger/listener/ContractAgreementEventSubscriber.java
+++ b/extensions/blockchain/logger/src/main/java/berlin/tu/ise/extension/blockchain/logger/listener/ContractAgreementEventSubscriber.java
@@ -114,7 +114,7 @@ public class ContractAgreementEventSubscriber implements EventSubscriber {
             }
 
             while ((returnJson = br.readLine()) != null) {
-                System.out.println(returnJson);
+                monitor.debug(returnJson);
                 ObjectMapper mapper = new ObjectMapper();
                 returnObject = mapper.readValue(returnJson, ReturnOperationObject.class);
             }

--- a/extensions/blockchain/logger/src/main/java/berlin/tu/ise/extension/blockchain/logger/listener/TransferProcessEventSubscriber.java
+++ b/extensions/blockchain/logger/src/main/java/berlin/tu/ise/extension/blockchain/logger/listener/TransferProcessEventSubscriber.java
@@ -133,7 +133,7 @@ public class TransferProcessEventSubscriber implements EventSubscriber {
             }
 
             while ((returnJson = br.readLine()) != null) {
-                System.out.println(returnJson);
+                monitor.debug(returnJson);
                 ObjectMapper mapper = new ObjectMapper();
                 returnObject = mapper.readValue(returnJson, ReturnOperationObject.class);
             }

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -9,6 +9,6 @@ ENV JAR_NAME "edc-tu-berlin.jar"
 ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
-COPY resources/logging/logging.properties .
+COPY ./home/gradle/src/resources/logging/logging.properties .
 
 ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.util.logging.config.file=logging.properties -jar $JAR_NAME"]

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -9,6 +9,6 @@ ENV JAR_NAME "edc-tu-berlin.jar"
 ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
-COPY ../../resources/logging/logging.properties .
+COPY resources/logging/logging.properties .
 
 ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.util.logging.config.file=logging.properties -jar $JAR_NAME"]

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -9,6 +9,9 @@ ENV JAR_NAME "edc-tu-berlin.jar"
 ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
-COPY --from=build ./home/gradle/src/resources/logging/logging.properties .
+
+RUN find / -name "logging.properties"
+
+COPY ./home/gradle/src/resources/logging/logging.properties .
 
 ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.util.logging.config.file=logging.properties -jar $JAR_NAME"]

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -9,6 +9,6 @@ ENV JAR_NAME "edc-tu-berlin.jar"
 ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
-COPY ./home/gradle/src/resources/logging/logging.properties .
+COPY --from=build ./home/gradle/src/resources/logging/logging.properties .
 
 ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.util.logging.config.file=logging.properties -jar $JAR_NAME"]

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -10,7 +10,7 @@ ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,add
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
 
-RUN find / -name "logging.properties"
+RUN find / -name "logging.properties" -print
 
 COPY ./home/gradle/src/resources/logging/logging.properties .
 

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -9,7 +9,6 @@ ENV JAR_NAME "edc-tu-berlin.jar"
 ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
-
 COPY ./resources/logging/logging.properties .
 
 ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.util.logging.config.file=logging.properties -jar $JAR_NAME"]

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -10,8 +10,6 @@ ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,add
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
 
-RUN find / -name "logging.properties" -print
-
-COPY ./home/gradle/src/resources/logging/logging.properties .
+COPY ./resources/logging/logging.properties .
 
 ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.util.logging.config.file=logging.properties -jar $JAR_NAME"]

--- a/launchers/azure/Dockerfile
+++ b/launchers/azure/Dockerfile
@@ -1,5 +1,5 @@
 FROM gradle:8.1.1-jdk17-alpine AS build
-COPY --chown=gradle:gradle . /home/gradle/src
+COPY --chown=gradle:gradle ../.. /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle launchers:azure:build
 
@@ -9,5 +9,6 @@ ENV JAR_NAME "edc-tu-berlin.jar"
 ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 COPY --from=build ./home/gradle/src/launchers/azure/build/libs/$JAR_NAME .
+COPY ../../resources/logging/logging.properties .
 
-ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -jar $JAR_NAME"]
+ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.util.logging.config.file=logging.properties -jar $JAR_NAME"]

--- a/launchers/azure/build.gradle.kts
+++ b/launchers/azure/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
     implementation(libs.edc.data.plane.api)
     implementation(libs.edc.data.plane.core)
     implementation(libs.edc.data.plane.http)
+
+    implementation(libs.edc.monitor.jdk.logger)
 }
 
 application {

--- a/resources/logging/logging.properties
+++ b/resources/logging/logging.properties
@@ -1,0 +1,6 @@
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+org.eclipse.edc.level=ALL
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n

--- a/resources/logging/logging.properties
+++ b/resources/logging/logging.properties
@@ -1,6 +1,5 @@
 handlers = java.util.logging.ConsoleHandler
 .level = INFO
-org.eclipse.edc.level=ALL
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n


### PR DESCRIPTION
## What this PR changes/adds

- LoggingMonitor instead of ConsoleMonitor for Logging so we can configure the log level for logging
- Added logging.properties with set log level to INFO.
- Refactoring: Dockerfile into Launcher
- Replaced some System.out.println() -> Rest will be done in https://github.com/GAIA-X4PLC-AAD/EDC-Blockchain-Catalog/issues/11

## Why it does that

We want to be able to set the log level. It was not possible with the default ConsoleLogger.

## Further notes

## Linked Issue(s)
https://github.com/GAIA-X4PLC-AAD/EDC-Blockchain-Catalog/issues/11
https://github.com/GAIA-X4PLC-AAD/EDC-Blockchain-Catalog/issues/8

Closes # https://github.com/GAIA-X4PLC-AAD/EDC-Blockchain-Catalog/issues/8

## Checklist

- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] documented code?
- [ ] assigned appropriate label?
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Samples/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)